### PR TITLE
PM-1854 "PM-1854 & PM-1853: Copiar la mejora del bug..." SOLVED

### DIFF
--- a/workflow/engine/classes/model/CaseScheduler.php
+++ b/workflow/engine/classes/model/CaseScheduler.php
@@ -320,11 +320,10 @@ class CaseScheduler extends BaseCaseScheduler
             }
 
             $sActualTime = $aRow['SCH_TIME_NEXT_RUN'];
-            $sActualDataHour = date( 'H', strtotime( $aRow['SCH_TIME_NEXT_RUN'] ) );
-            $sActualDataMinutes = date( 'i', strtotime( $aRow['SCH_TIME_NEXT_RUN'] ) );
-            $dActualSysHour = date( 'H', $nTime );
-            $dActualSysHour = ($dActualSysHour == '00') ? '24' : $dActualSysHour;
-            $dActualSysMinutes = date( 'i', $nTime );
+            $sActualDataHour    = (int)(date("H", strtotime($aRow["SCH_TIME_NEXT_RUN"])));
+            $sActualDataMinutes = (int)(date("i", strtotime($aRow["SCH_TIME_NEXT_RUN"])));
+            $dActualSysHour     = (int)(date("H", $nTime));
+            $dActualSysMinutes  = (int)(date("i", $nTime));
             $sActualDataTime = strtotime( $aRow['SCH_TIME_NEXT_RUN'] );
             $sActualSysTime = strtotime( $nTime );
 


### PR DESCRIPTION
Issue:
    PM-1854 Copiar la mejora del bug PM-1764 sobre la version 2.5.2.5 para preparar el hotfix v2.5.2.6
    PM-1853 Copiar la mejora del bug PM-1790 sobre la version 2.5.2.5 para preparar el hotfix 2.5.2.6
Cause:
    Hora hardcodeada a "24" cuando se trataba de las cero horas ("00")
Solution:
    - Se ha eliminado esta linea
    - Se ha aplicado el cast-to-int para las horas y minutos