### PR TITLE
Fix of error: Failure loading root node

### DIFF
--- a/gulliver/system/class.form.php
+++ b/gulliver/system/class.form.php
@@ -767,7 +767,7 @@ class Form extends XmlForm
      */
     public static function createXMLFileIfNotExists($filepath)
     {
-        if (file_exists($filepath)) {
+        if (file_exists($filepath) && filesize($filepath) > 0) {
             return;
         }
         $pathParts = pathinfo($filepath);


### PR DESCRIPTION
In some situations the xml files in /opt/processmaker/shared/sites/{workspace}/xmlForms/{app uid} are corrupted and have a zero size.  This caused the error 'Failure loading root node'.  This change updates the code in /opt/processmaker/gulliver/system/class.form.php around line 768.  The original code creates the file if it doesn't exist.  This change will also recreate the file if it is zero size.